### PR TITLE
fix: rtl detection

### DIFF
--- a/src/lib/utils/data-extraction.ts
+++ b/src/lib/utils/data-extraction.ts
@@ -34,7 +34,7 @@ export function getItemRects(list: HTMLUListElement): ItemRect[] {
 	);
 }
 
-export const getTextDirection = (element?: HTMLElement): HTMLElement['dir'] => {
+export const getTextDirection = (element: HTMLElement): HTMLElement['dir'] => {
 	if (!element) return 'auto';
 
 	try {

--- a/src/lib/utils/data-extraction.ts
+++ b/src/lib/utils/data-extraction.ts
@@ -37,12 +37,7 @@ export function getItemRects(list: HTMLUListElement): ItemRect[] {
 export const getTextDirection = (element: HTMLElement): HTMLElement['dir'] => {
 	if (!element) return 'auto';
 
-	try {
-	  const dir = window.getComputedStyle(element).direction;
-		return dir || 'auto';
-	} catch (e) {
-		return 'auto
-	}
+	return window.getComputedStyle(element).direction || 'auto';
 };
 
 function preserveInputValue(source: HTMLInputElement, clone: HTMLInputElement): void {

--- a/src/lib/utils/data-extraction.ts
+++ b/src/lib/utils/data-extraction.ts
@@ -34,16 +34,15 @@ export function getItemRects(list: HTMLUListElement): ItemRect[] {
 	);
 }
 
-export const getTextDirection = (element: HTMLElement): HTMLElement['dir'] => {
+export const getTextDirection = (element?: HTMLElement): HTMLElement['dir'] => {
 	if (!element) return 'auto';
 
-	let parent = element.parentElement;
-	while (parent) {
-		if (parent.getAttribute('dir')) return parent.getAttribute('dir') as HTMLElement['dir'];
-		parent = parent.parentElement;
+	try {
+	  const dir = window.getComputedStyle(element).direction;
+		return dir || 'auto';
+	} catch (e) {
+		return 'auto
 	}
-
-	return 'auto';
 };
 
 function preserveInputValue(source: HTMLInputElement, clone: HTMLInputElement): void {


### PR DESCRIPTION
RTL and LTR can be set in multiple ways, not just with the dir attribute.
The best approach—rather than traversing the DOM tree—is to use the computed style.

This way, whether the application uses a `dir` attribute or the CSS `direction` property, you’ll always get the correct value.
